### PR TITLE
Add feature for additional time to view images

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,23 @@ Display variables for text labels:
 | `{seconds_text}` | Displays the Seconds Text Label (Singular or Plural, Based on Number of Seconds) | `seconds` |
 
 >> NOTE: Any time you are making alterations to a theme's files, you will want to duplicate the theme folder in the `user/themes/` directory, rename it, and set the new name as your active theme. This will ensure that you don't lose your customizations in the event that a theme is updated. Once you have tested the change thoroughly, you can delete or back up that folder elsewhere.
+
+### Include image views
+The number of seconds to view images is added to the reading time of text when `include_image_views` is set to true.
+
+Images are identified by `<img>` tags in `page.content()`.
+
+The default values for `seconds_per_image` (shown below) mean that the first image adds `12` seconds to the reading time, the second adds `11` seconds, the third adds `10` seconds, and so on.
+Only integers, whitespace, and commas are permitted in the string.
+
+```
+seconds_per_image: '12,11,10,9,8,7,6,5,4,3'
+```
+
+If there are more images in a page than what is defined in `seconds_per_image` (e.g., more than 10 images in the default shown above) then subsequent images take the last value (`3` seconds in the default shown above).
+
+The example below adds `5` seconds reading time for all images.
+
+```
+seconds_per_image: 5
+```

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -49,3 +49,24 @@ form:
       options:
           seconds: second
           minutes: minute
+
+    include_image_views:
+      type: toggle
+      label: Include time for viewing images
+      highlight: 1
+      default: 0
+      options:
+        1: Enabled
+        0: Disabled
+      validate:
+        type: bool
+
+    seconds_per_image:
+      type: text
+      label: Seconds to view images
+      help: 'Comma-separated list of whole numbers where first number is the number of seconds to view the first image, second number for the second image, and so on. Example: 12,10,11'
+      default: '12,11,10,9,8,7,6,5,4,3'
+      validate:
+        required: true
+        pattern: '(^(\s*\d+\s*))?(,\s*\d+\s*)*'
+        message: 'Must be a comma-separated list of whole numbers (e.g. 12,11,10) with at least one number'

--- a/readingtime.yaml
+++ b/readingtime.yaml
@@ -2,3 +2,5 @@ enabled: true
 words_per_minute: 200
 format: "{minutes_short_count} {minutes_text}, {seconds_short_count} {seconds_text}"
 round: seconds
+include_image_views: false
+seconds_per_image: '12,11,10,9,8,7,6,5,4,3'


### PR DESCRIPTION
This adds an optional feature to include additional reading time that is associated with viewing images. This refers to issue #16.

This is my first PR, so any feedback and guidance would be very helpful for me.

A note on implementation: I used a string to store an array of integers (`seconds_per_image`) so it could be validated in the user interface by using regex. I tried using an array in blueprints.yaml but I could not understand how to validate the content of each string item in the array.