### PR TITLE
Support for reading time ranges

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -36,6 +36,23 @@ form:
         min: 1
         max: 1000
 
+    estimate_range:
+      type: text
+      size: x-small
+      append: ±%
+      help: 'Percentage to add and remove from the reading time estimate to get a reading time range. 10% on a 10-minute read would give 9–11 minutes.'
+      label: Reading time estimate range
+      validate:
+        type: int
+        min: 0
+        max: 100
+
+    range_str:
+      type: text
+      label: Estimate range string
+      help: 'String to use between the low and high estimate range numbers (e.g., "—", "-", " to ", etc.).'
+      size: x-small
+
     format:
       type: text
       label: Format

--- a/classes/TwigReadingTimeFilters.php
+++ b/classes/TwigReadingTimeFilters.php
@@ -105,6 +105,23 @@ class TwigReadingTimeFilters extends Twig_Extension
 
     $minutes_long_count = number_format($minutes_short_count, 2);
     $seconds_long_count = number_format($seconds_short_count, 2);
+    $minutes_low_range_long = number_format($minutes_low_range, 2);
+    $minutes_high_range_long = number_format($minutes_high_range, 2);
+
+    if ($minutes_low_range == $minutes_high_range or $minutes_low_range == 0) {
+      $minutes_range_short = $minutes_short_count;
+      $minutes_range_long = $minutes_long_count;
+    } elseif ($minutes_low_range == 0) {
+      $minutes_range_short = $minutes_short_count;
+      $minutes_range_long = $minutes_long_count;
+    } else {
+      $minutes_range_short = (
+        $minutes_low_range . $range_str . $minutes_high_range
+      );
+      $minutes_range_long = (
+        $minutes_low_range_long . $range_str . $minutes_high_range_long
+      );
+    }
 
     if (array_key_exists('minute_label', $options) and $minutes_short_count == 1) {
       $minutes_text = $options['minute_label'];

--- a/classes/TwigReadingTimeFilters.php
+++ b/classes/TwigReadingTimeFilters.php
@@ -140,12 +140,14 @@ class TwigReadingTimeFilters extends Twig_Extension
     }
 
     $replace = [
-      'minutes_short_count'   => $minutes_short_count,
-      'seconds_short_count'   => $seconds_short_count,
-      'minutes_long_count'    => $minutes_long_count,
-      'seconds_long_count'    => $seconds_long_count,
-      'minutes_text'          => $minutes_text,
-      'seconds_text'          => $seconds_text
+      'minutes_short_count' => $minutes_short_count,
+      'minutes_range_short' => $minutes_range_short,
+      'seconds_short_count' => $seconds_short_count,
+      'minutes_long_count'  => $minutes_long_count,
+      'minutes_range_long'  => $minutes_range_long,
+      'seconds_long_count'  => $seconds_long_count,
+      'minutes_text'        => $minutes_text,
+      'seconds_text'        => $seconds_text
     ];
 
     $result = $options['format'];

--- a/classes/TwigReadingTimeFilters.php
+++ b/classes/TwigReadingTimeFilters.php
@@ -109,16 +109,16 @@ class TwigReadingTimeFilters extends Twig_Extension
     $minutes_high_range_long = number_format($minutes_high_range, 2);
 
     if ($minutes_low_range == $minutes_high_range or $minutes_low_range == 0) {
-      $minutes_range_short = $minutes_short_count;
-      $minutes_range_long = $minutes_long_count;
+      $minutes_short_range = $minutes_short_count;
+      $minutes_long_range = $minutes_long_count;
     } elseif ($minutes_low_range == 0) {
-      $minutes_range_short = $minutes_short_count;
-      $minutes_range_long = $minutes_long_count;
+      $minutes_short_range = $minutes_short_count;
+      $minutes_long_range = $minutes_long_count;
     } else {
-      $minutes_range_short = (
+      $minutes_short_range = (
         $minutes_low_range . $range_str . $minutes_high_range
       );
-      $minutes_range_long = (
+      $minutes_long_range = (
         $minutes_low_range_long . $range_str . $minutes_high_range_long
       );
     }
@@ -141,10 +141,10 @@ class TwigReadingTimeFilters extends Twig_Extension
 
     $replace = [
       'minutes_short_count' => $minutes_short_count,
-      'minutes_range_short' => $minutes_range_short,
+      'minutes_short_range' => $minutes_short_range,
       'seconds_short_count' => $seconds_short_count,
       'minutes_long_count'  => $minutes_long_count,
-      'minutes_range_long'  => $minutes_range_long,
+      'minutes_long_range'  => $minutes_long_range,
       'seconds_long_count'  => $seconds_long_count,
       'minutes_text'        => $minutes_text,
       'seconds_text'        => $seconds_text

--- a/classes/TwigReadingTimeFilters.php
+++ b/classes/TwigReadingTimeFilters.php
@@ -51,6 +51,8 @@ class TwigReadingTimeFilters extends Twig_Extension
 
     $words = count(preg_split('/\s+/', strip_tags($content)) ?: []);
     $wpm = $options['words_per_minute'];
+    $estimate_range = ($options['estimate_range'] / 100);
+    $range_str = $options['range_str'];
 
     $minutes_short_count = floor($words / $wpm);
     $seconds_short_count = floor($words % $wpm / ($wpm / 60));
@@ -91,7 +93,7 @@ class TwigReadingTimeFilters extends Twig_Extension
 
     $minutes_long_count = number_format($minutes_short_count, 2);
     $seconds_long_count = number_format($seconds_short_count, 2);
-    
+
     if (array_key_exists('minute_label', $options) and $minutes_short_count == 1) {
       $minutes_text = $options['minute_label'];
     } elseif (array_key_exists('minutes_label', $options) and $minutes_short_count > 1) {

--- a/classes/TwigReadingTimeFilters.php
+++ b/classes/TwigReadingTimeFilters.php
@@ -57,6 +57,9 @@ class TwigReadingTimeFilters extends Twig_Extension
     $minutes_short_count = floor($words / $wpm);
     $seconds_short_count = floor($words % $wpm / ($wpm / 60));
 
+    $minutes_low_range = floor(($words * (1 - $estimate_range)) / $wpm);
+    $minutes_high_range = floor(($words * (1 + $estimate_range)) / $wpm);
+
     if ($options['include_image_views']) {
       $stripped = strip_tags($content, "<img>");
       $images_in_content = substr_count($stripped, "<img ");
@@ -74,6 +77,9 @@ class TwigReadingTimeFilters extends Twig_Extension
 
           $minutes_short_count += floor($seconds_images / 60);
           $seconds_short_count += $seconds_images % 60;
+
+          $minutes_low_range += floor(($seconds_images * (1 - $estimate_range)) / 60);
+          $minutes_high_range += floor(($seconds_images * (1 - $estimate_range)) / 60);
         } else {
           $this->grav['log']->error("Plugin 'readingtime' - seconds_per_image failed regex vadation");
         }
@@ -82,10 +88,16 @@ class TwigReadingTimeFilters extends Twig_Extension
 
     $round = $options['round'];
     if ($round == 'minutes') {
-      $minutes_short_count = round(($minutes_short_count*60 + $seconds_short_count) / 60);
+      $minutes_short_count = round(($minutes_short_count * 60 + $seconds_short_count) / 60);
+
+      $minutes_low_range = round(($minutes_low_range * 60 + $seconds_low_range) / 60);
+      $minutes_high_range = round(($minutes_high_range * 60 + $seconds_high_range) / 60);
 
       if ( $minutes_short_count < 1 ) {
         $minutes_short_count = 1;
+
+        $minutes_low_range = 0;
+        $minutes_high_range = 1;
       }
 
       $seconds_short_count = 0;

--- a/readingtime.yaml
+++ b/readingtime.yaml
@@ -1,5 +1,7 @@
 enabled: true
 words_per_minute: 200
+estimate_range: 15
+range_str: "–"
 format: "{minutes_short_count} {minutes_text}, {seconds_short_count} {seconds_text}"
 round: seconds
 include_image_views: false


### PR DESCRIPTION
Adds support for reading time estimate ranges (e.g., "5–7 minutes", "19 to 23 minutes").

Two new settings:

* `estimate_range` [default: 15]: The percentage range for the reading time range estimate (e.g., ±15%).
* `range_str` [default: –]: The string that joins the low and high estimates (e.g., "–", "-", " to ").

Two new format variables:

* `{minutes_short_range}`: Same as `{minutes_short_count}` but gives a range joined by `range_str` (e.g. "11–15")
* `{minutes_long_range}`: Same as `{minutes_long_count}` but gives a range joined by `range_str` (e.g., "05 to 07")

The estimate is calculated as the normal reading time estimate ± the `estimate_range` percent, so a 15% range would give you reading time minus 15% for the low estimate and plus 15% for the high estimate.

If the range has the same values for the low and high estimate it will return the count instead (e.g,. "1–1" returns "1") and will appropriately match the `{minutes_text}`. If the range floors out at 0, then also return the count instead.

I did not implement any support for seconds here, as it added complexity for spurious precision of dubious utility—"13 minutes 16 seconds to 17 minutes 56 seconds" doesn't add much over (13 to 18 minutes).